### PR TITLE
Fix alignment issue in details section

### DIFF
--- a/_layouts/studentDetails.html
+++ b/_layouts/studentDetails.html
@@ -192,7 +192,7 @@ NOTES:
                 <div class="card-body">
                     <div class="row">
                         <div class="col-sm-3">
-                            <h6 class="mb-0">Full Name</h6>
+                            <span class="mb-0" style="font-weight: 500">Full Name</span>
                         </div>
                         <div class="col-sm-9 text-secondary">
                             {{page.full_name}}
@@ -201,7 +201,7 @@ NOTES:
                     <hr>
                     <div class="row">
                         <div class="col-sm-3">
-                            <h6 class="mb-0">Preferred Name</h6>
+                            <span class="mb-0" style="font-weight: 500">Preferred Name</span>
                         </div>
                         <div class="col-sm-9 text-secondary">
                             {{page.preferred_long_name}}
@@ -210,7 +210,7 @@ NOTES:
                     <hr>
                     <div class="row">
                         <div class="col-sm-3">
-                            <h6 class="mb-0">Registration Number</h6>
+                            <span class="mb-0" style="font-weight: 500">Registration Number</span>
                         </div>
                         <div class="col-sm-9 text-secondary">
                             {{page.reg_no}}
@@ -219,7 +219,7 @@ NOTES:
                     <hr>
                     <div class="row">
                         <div class="col-sm-3">
-                            <h6 class="mb-0">Email</h6>
+                            <span class="mb-0" style="font-weight: 500">Email</span>
                         </div>
                         <div class="col-sm-9 text-secondary">
                             {{page.email_faculty}} , {{page.email_personal}}
@@ -228,7 +228,7 @@ NOTES:
                     <hr>
                     <div class="row">
                         <div class="col-sm-3">
-                            <h6 class="mb-0">Location</h6>
+                            <span class="mb-0" style="font-weight: 500">Location</span>
                         </div>
                         <div class="col-sm-9 text-secondary">
                             {{page.location}}


### PR DESCRIPTION
## Purpose
Fixing the alignment issue in the basic details section on the student page

## Screenshots
Previous one:
<img src="https://user-images.githubusercontent.com/27498587/141423592-ddf1915b-1949-4f24-a86c-1ec315169b7d.png">

After updating:
<img src="https://user-images.githubusercontent.com/27498587/141423653-188ca210-bc70-429b-b66e-fa0037e1770c.png">


Note: Use squash and merge when merging (instead of merge commit)